### PR TITLE
fix: replace patreon reference with ko-fi

### DIFF
--- a/client/src/app/pages/dashboard/misc/SupportMePage.tsx
+++ b/client/src/app/pages/dashboard/misc/SupportMePage.tsx
@@ -5,7 +5,7 @@ import React from "react";
 import { Link } from "react-router-dom";
 
 export default function SupportMePage() {
-	useSetSubheader("Support / Patreon");
+	useSetSubheader("Support / Ko-fi");
 
 	return (
 		<div style={{ fontSize: "1.15rem" }}>
@@ -15,7 +15,7 @@ export default function SupportMePage() {
 			</p>
 			<p>
 				If you want to support {TachiConfig.NAME} development, you can donate to my{" "}
-				<ExternalLink href="https://ko-fi.com/zkrising">Ko-Fi</ExternalLink>.
+				<ExternalLink href="https://ko-fi.com/zkrising">Ko-fi</ExternalLink>.
 			</p>
 			<p>
 				Alternatively, you can star the{" "}


### PR DESCRIPTION
ko-fi is also styled "Ko-fi" apparently, so just edited that too

was randomly browsing and saw that the "Support" page still referenced Patreon in the title, and decided to change it. Perhaps it would be better to remove it from the title completely?